### PR TITLE
Fix bug causing widget to disappear when all rules deleted

### DIFF
--- a/R/queryBuilder.R
+++ b/R/queryBuilder.R
@@ -33,7 +33,7 @@ queryBuilder <- function(data = NULL,
     if (is.null(data)) return(NULL)
     filters <- list()
     columnTypes <- sapply(data, class)
-    for (i in 1:length(columnTypes)) {
+    for (i in seq_along(columnTypes)) {
       c <- columnTypes[i]
       if(c == 'numeric') {
         filters[[length(filters) + 1]] <- list(name = names(c), type = 'double')
@@ -60,7 +60,7 @@ queryBuilder <- function(data = NULL,
 #     if (!all(nonFunctionFilters %in% names(data))) return()
   }
 
-  for (i in 1:length(filters)) {
+  for (i in seq_along(filters)) {
     if (filters[[i]]['input'] %in% c('select', 'selectize', 'radio')) {
       if (!'values' %in% names(filters[[i]])) {
         if (is.null(data) | !filters[[i]][['name']] %in% names(data)) {
@@ -201,7 +201,7 @@ lookup <- function(id, operator, value) {
 recurseFilter <- function(filter = NULL) {
   condition <- list('AND' = '&', 'OR' = '|')
   fs <- NULL
-  for (i in 1:length(filter$rules)) {
+  for (i in seq_along(filter$rules)) {
     if (typeof(filter$rules[[i]]$rules) == 'list') {  # nested filter group
       if (is.null(fs)) {
         fs <- paste0('(', recurseFilter(filter = filter$rules[[i]]), ')')  # first filter

--- a/R/queryBuilder.R
+++ b/R/queryBuilder.R
@@ -29,6 +29,8 @@ queryBuilder <- function(data = NULL,
                          width = NULL,
                          height = NULL) {
 
+  if (!length(rules)) rules <- NULL
+
   if(autoassign == TRUE) {
     if (is.null(data)) return(NULL)
     filters <- list()
@@ -111,7 +113,7 @@ queryBuilder <- function(data = NULL,
 #' @export
 filterTable <- function(filters = NULL, data = NULL, output = c('table', 'text')) {
   output <-  match.arg(output)
-  if (is.null(filters) | is.null(data)) return(data)
+  if (is.null(filters) || !length(filters) || is.null(data)) return(data)
   ## Run through list recursively and generate a filter
   f <- recurseFilter(filters)
   if (output == 'text') {

--- a/R/queryBuilder.R
+++ b/R/queryBuilder.R
@@ -110,6 +110,7 @@ queryBuilder <- function(data = NULL,
 #'
 #' @export
 filterTable <- function(filters = NULL, data = NULL, output = c('table', 'text')) {
+  output <-  match.arg(output)
   if (is.null(filters) | is.null(data)) return(data)
   ## Run through list recursively and generate a filter
   f <- recurseFilter(filters)


### PR DESCRIPTION
Fix previous behavior that caused a warning with length 2 condition.

Example warning:

```
Warning in if (output == "text") { :
  the condition has length > 1 and only the first element will be used
```