### PR TITLE
Define valueSetter for selectize inputs (solves #11)

### DIFF
--- a/inst/htmlwidgets/queryBuilder.js
+++ b/inst/htmlwidgets/queryBuilder.js
@@ -93,6 +93,9 @@ HTMLWidgets.widget({
               i.values.forEach(function(x) { selectizeOptions.push({ id: x })});
               myFilter.plugin_config = { "valueField" : "id", "labelField" : "id", "maxItems" : null, "create" : false, "options" : selectizeOptions };
               myFilter.valueGetter = function(rule) { return rule.$el.find('.selectized').selectize()[0].selectize.items; };
+              myFilter.valueSetter = function (rule, value) {
+                rule.$el.find('.rule-value-container input')[0].selectize.setValue(value);
+              };
             }
          }
         } else if (i.type == 'date') {


### PR DESCRIPTION
For selectize inputs, one has to define a valueSetter function; otherwise a predefined rule which includes the selectize input will not work as expected. The solution is described [here](https://github.com/mistic100/jQuery-QueryBuilder/issues/189), I just added the valueSetter function to the appropriate row in the queryBuilder.js file. 